### PR TITLE
Adds BMP3XX Low-cost high-precision pressure sensor support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         repository: 'RPi-Distro/pi-gen'
         path: PiGen
         fetch-depth: 1
-        ref: 66255495f29be5d09b765d081aff6fc0f11e59b4
+        ref: 9249e146d2e3987adf2ea0e5e19e295d37f3f886
 
     # This is where we install all of our PiGen extras.
     # Helpful:  https://geoffhudik.com/tech/2020/05/15/using-pi-gen-to-build-a-custom-raspbian-lite-image/
@@ -141,7 +141,7 @@ jobs:
         repository: 'RPi-Distro/pi-gen'
         path: PiGen
         fetch-depth: 1
-        ref: 66255495f29be5d09b765d081aff6fc0f11e59b4
+        ref: 9249e146d2e3987adf2ea0e5e19e295d37f3f886
 
     # This is where we install all of our PiGen extras.
     # Helpful:  https://geoffhudik.com/tech/2020/05/15/using-pi-gen-to-build-a-custom-raspbian-lite-image/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         repository: 'RPi-Distro/pi-gen'
         path: PiGen
         fetch-depth: 1
-        ref: 9249e146d2e3987adf2ea0e5e19e295d37f3f886
+        ref: 66255495f29be5d09b765d081aff6fc0f11e59b4
 
     # This is where we install all of our PiGen extras.
     # Helpful:  https://geoffhudik.com/tech/2020/05/15/using-pi-gen-to-build-a-custom-raspbian-lite-image/
@@ -141,7 +141,7 @@ jobs:
         repository: 'RPi-Distro/pi-gen'
         path: PiGen
         fetch-depth: 1
-        ref: 9249e146d2e3987adf2ea0e5e19e295d37f3f886
+        ref: 66255495f29be5d09b765d081aff6fc0f11e59b4
 
     # This is where we install all of our PiGen extras.
     # Helpful:  https://geoffhudik.com/tech/2020/05/15/using-pi-gen-to-build-a-custom-raspbian-lite-image/

--- a/custom_pigen/stage2/01-sys-tweaks/00-patches/90-firstboot.diff
+++ b/custom_pigen/stage2/01-sys-tweaks/00-patches/90-firstboot.diff
@@ -1,0 +1,11 @@
+--- a/rootfs/usr/lib/raspberrypi-sys-mods/firstboot	2023-03-26 15:00:41.355880751 +0100
++++ b/rootfs/usr/lib/raspberrypi-sys-mods/firstboot	2023-03-26 15:02:49.028446093 +0100
+@@ -63,7 +63,7 @@
+ fix_partuuid() {
+   mount -o remount,rw "$ROOT_PART_DEV"
+   mount -o remount,rw "$BOOT_PART_DEV"
+-  DISKID="$(tr -dc 'a-f0-9' < /dev/hwrng | dd bs=1 count=8 2>/dev/null)"
++  DISKID="$(tr -dc 'a-f0-9' < /dev/urandom | dd bs=1 count=8 2>/dev/null)"
+   fdisk "$ROOT_DEV" > /dev/null <<EOF
+ x
+ i

--- a/custom_pigen/stage2/01-sys-tweaks/00-patches/90-regenerate_ssh_host_keys.diff
+++ b/custom_pigen/stage2/01-sys-tweaks/00-patches/90-regenerate_ssh_host_keys.diff
@@ -1,0 +1,11 @@
+--- a/rootfs/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys	2023-03-26 15:00:41.355880751 +0100
++++ b/rootfs/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys	2023-03-26 15:02:49.028446093 +0100
+@@ -1,8 +1,5 @@
+ #!/bin/sh -e
+ 
+-if [ -c /dev/hwrng ]; then
+-  dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 status=none
+-fi
+ rm -f /etc/ssh/ssh_host_*_key*
+ ssh-keygen -A > /dev/null
+ systemctl -q disable regenerate_ssh_host_keys

--- a/custom_pigen/stage2/01-sys-tweaks/00-patches/series
+++ b/custom_pigen/stage2/01-sys-tweaks/00-patches/series
@@ -1,0 +1,7 @@
+01-useradd.diff
+02-swap.diff
+04-inputrc.diff
+05-path.diff
+07-resize-init.diff
+90-regenerate_ssh_host_keys.diff
+90-firstboot.diff

--- a/custom_pigen/stage2/04-install-requirements/03-run.sh
+++ b/custom_pigen/stage2/04-install-requirements/03-run.sh
@@ -15,6 +15,7 @@ EOF
 # https://github.com/torfsen/python-systemd-tutorial is awesome.
 cp files/simpleaq.service "${ROOTFS_DIR}/etc/systemd/system"
 cp files/hostap_config.service "${ROOTFS_DIR}/etc/systemd/system"
+cp files/dnsmasq.service "${ROOTFS_DIR}/etc/systemd/system"
 
 # SimpleAQ uses python-dotenv.
 # We will set the environment variables for SimpleAQ at the system level.

--- a/custom_pigen/stage2/04-install-requirements/files/dnsmasq.service
+++ b/custom_pigen/stage2/04-install-requirements/files/dnsmasq.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=dnsmasq - A lightweight DHCP and caching DNS server
+Requires=network.target
+Wants=nss-lookup.target
+Before=nss-lookup.target
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/dnsmasq/dnsmasq.pid
+
+# Automatically restart the service if it flakes.
+Restart=on-failure
+RestartSec=15s
+
+# Test the config file and refuse starting if it is not valid.
+ExecStartPre=/etc/init.d/dnsmasq checkconfig
+
+# We run dnsmasq via the /etc/init.d/dnsmasq script which acts as a
+# wrapper picking up extra configuration files and then execs dnsmasq
+# itself, when called with the "systemd-exec" function.
+ExecStart=/etc/init.d/dnsmasq systemd-exec
+
+# The systemd-*-resolvconf functions configure (and deconfigure)
+# resolvconf to work with the dnsmasq DNS server. They're called like
+# this to get correct error handling (ie don't start-resolvconf if the
+# dnsmasq daemon fails to start).
+ExecStartPost=/etc/init.d/dnsmasq systemd-start-resolvconf
+ExecStop=/etc/init.d/dnsmasq systemd-stop-resolvconf
+
+
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/devices/bmp3xx.py
+++ b/devices/bmp3xx.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from absl import logging
+from . import Sensor
+
+import board
+import adafruit_bmp3xx
+
+
+class Bmp3xx(Sensor):
+  def __init__(self, remotestorage, localstorage, timesource, **kwargs):
+    super().__init__(remotestorage, localstorage, timesource)
+    self.sensor = adafruit_bmp3xx.BMP3XX_I2C(board.I2C())
+
+  def publish(self):
+    logging.info('Publishing Bmp3xx to remote')
+    result = False
+    try:
+      # It is actually important that the try_write_to_remote happens before the result, otherwise
+      # it will never be evaluated!
+      result = self._try_write_to_remote('BMP3XX', 'temperature_C', self.sensor.temperature) or result
+      result = self._try_write_to_remote('BMP3XX', 'pressure_hPa', self.sensor.pressure) or result
+    except Exception as err:
+      logging.error("Error getting data from BMP3XX.  Is this sensor correctly installed and the cable attached tightly:  " + str(err));
+      result = True
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ adafruit-python-shell
 adafruit-circuitpython-gps
 adafruit-circuitpython-pm25
 adafruit-circuitpython-bme680
+adafruit-circuitpython-bmp3xx
 influxdb_client
 python-dotenv
 sensirion-i2c-sen5x

--- a/simpleaq.py
+++ b/simpleaq.py
@@ -12,6 +12,7 @@ import dotenv
 
 from devices.system import System
 from devices.bme688 import Bme688
+from devices.bmp3xx import Bmp3xx
 from devices.gps import Gps
 from devices.pm25 import Pm25
 from devices.sen5x import Sen5x
@@ -46,6 +47,7 @@ def switch_to_wlan():
 device_map = {
     'system': System,
     'bme688': Bme688,
+    'bmp3xx': Bmp3xx,
     'gps': Gps,
     'pm25': Pm25,
     'sen5x': Sen5x


### PR DESCRIPTION
- Adds auto-detecting, plug-and-play support for BMP3XX sensors.
- Works around issue whereby we were stuck forever on generating SSH keys on first boot (https://github.com/RPi-Distro/pi-gen/issues/682)
- Automatically restarts `dnsmasq` should it go down.  It was frequently flaky, so users sometimes had to power-cycle devices in the case where they needed to reconfigure due to a changed wifi password or credentials.
- Updates us to the newest Pi-Gen.