### PR TITLE
In preparation for one-click configuration, switch update from POST to GET.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     </center>
   </td>
 </tr>
-<form method="post" action="update">
+<form method="get" action="update">
 <tr>
   <th>Setting</th>
   <th>Value</th>


### PR DESCRIPTION
https://github.com/simpleairquality/SimpleAQ-Frontend/issues/166

Obviously we wish that we could use HTTP POST for anything that changes state, but that's not going to be compatible with an automatic configuration link from simpleaq.org to a local device that does not support https.